### PR TITLE
Added support to configure routing rules (redirects) for s3 bucket from config file.

### DIFF
--- a/lib/configure-s3-website/config_source/config_source.rb
+++ b/lib/configure-s3-website/config_source/config_source.rb
@@ -11,5 +11,8 @@ module ConfigureS3Website
 
     def s3_endpoint
     end
+
+    def routing_rules
+    end
   end
 end

--- a/lib/configure-s3-website/config_source/file_config_source.rb
+++ b/lib/configure-s3-website/config_source/file_config_source.rb
@@ -23,6 +23,10 @@ module ConfigureS3Website
       @config['s3_endpoint']
     end
 
+    def routing_rules
+      @config['routing_rules']
+    end
+
     private
 
     def parse_config(yaml_file_path)


### PR DESCRIPTION
I have yet had time to create any tests (and I probably won't any time soon), but I wanted to go ahead and create the pull request as a reminder, and in case it helps anyone else.

I really like using the jekyll-s3 gem to manage our jekyll-generated static site deployment on S3. I think it's awesome being able to contain the deployment configuration in the repo.

In developing one of our sites though, I had to change the bucket a couple times, since the bucket name must match the desired CNAME for the custom domain, and we changed the subdomain a couple times. Doing so made me realize that there's an important part to the S3 website configuration that I had to re-do manually through the AWS console for each new bucket, and that is the [routing (aka redirect) rules](http://docs.aws.amazon.com/AmazonS3/latest/dev/HowDoIWebsiteConfiguration.html#configure-bucket-as-website-routing-rule-syntax).

Once I realized that the configure-s3-website gem uses the [PUT Bucket Website](http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTwebsite.html) API, and that the routing rules could be specified by the same API endpoint, it didn't seem like much of a stretch to add routing rules support to the gem.

With this pull request, for existing jekyll-s3 projects with no routing rules, one line is added to the output of the `configure-s3-website` command:

```
$ configure-s3-website --config-file _jekyll_s3.yml
Bucket www.example.com now functions as a website
Bucket www.example.com is now readable to the whole world
No redirects to configure for www.example.com bucket.
```

But now we can optionally include routing rules in our _jekyll_s3.yml config file, like this:

``` yml
s3_id: S3_SECRET_ID
s3_secret: S3_SECRET_KEY
s3_bucket: S3_BUCKET
routing_rules:
  - condition:
      key_prefix_equals: blog/some_path
    redirect:
      host_name: blog.example.com
      replace_key_prefix_with: some_new_path/
      http_redirect_code: 301
  - condition:
      key_prefix_equals: blog/another_old_path/
    redirect:
      host_name: blog.example.com
      replace_key_prefix_with: another_new_path/
      http_redirect_code: 301
  - condition:
      key_prefix_equals: blog/my_old_project/
    redirect:
      host_name: projects.example.com
      replace_key_prefix_with: my_old_project/
      http_redirect_code: 301
```

Now the redirects will automatically be configured for us on the S3 bucket:

```
$ configure-s3-website --config-file _jekyll_s3.yml
Bucket www.example.com now functions as a website
Bucket www.example.com is now readable to the whole world
3 redirects configured for www.example.com bucket.
```

Any of the other condition and redirect keys can be used from the API redirect documentation linked above, e.g. `replace_key_with` instead of `replace_key_prefix_with`, etc., it will just translate the underscore-formatted keys in the yaml file to the camelcase-formatted keys in the XML string that gets sent with the API call.

So the above yaml config sends this with the API call:

``` xml
          <WebsiteConfiguration xmlns='http://s3.amazonaws.com/doc/2006-03-01/'>
            <IndexDocument>
              <Suffix>index.html</Suffix>
            </IndexDocument>
            <ErrorDocument>
              <Key>error.html</Key>
            </ErrorDocument>
            <RoutingRules>

              <RoutingRule>

              <Condition>
                <KeyPrefixEquals>blog/some_path</KeyPrefixEquals></Condition>
              <Redirect>
                <HostName>blog.example.com</HostName>
                <ReplaceKeyPrefixWith>some_new_path/</ReplaceKeyPrefixWith>
                <HttpRedirectCode>301</HttpRedirectCode></Redirect>
              </RoutingRule>

              <RoutingRule>

              <Condition>
                <KeyPrefixEquals>blog/another_old_path/</KeyPrefixEquals></Condition>
              <Redirect>
                <HostName>blog.example.com</HostName>
                <ReplaceKeyPrefixWith>another_new_path/</ReplaceKeyPrefixWith>
                <HttpRedirectCode>301</HttpRedirectCode></Redirect>
              </RoutingRule>

              <RoutingRule>

              <Condition>
                <KeyPrefixEquals>blog/my_old_project/</KeyPrefixEquals></Condition>
              <Redirect>
                <HostName>projects.example.com</HostName>
                <ReplaceKeyPrefixWith>my_old_project/</ReplaceKeyPrefixWith>
                <HttpRedirectCode>301</HttpRedirectCode></Redirect>
              </RoutingRule>

            </RoutingRules>
          </WebsiteConfiguration>
```
