### PR TITLE
Allow custom IndexDocument and ErrorDocument

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,19 @@ configuration file a row like this:
 The valid *s3_endpoint* values consist of the [S3 location constraint
 values](http://docs.amazonwebservices.com/general/latest/gr/rande.html#s3_region).
 
+
+### Specifying non-standard index or error documents
+
+By default, `configure-s3-website` uses `index.html` for the index document and `error.html` for the error document.
+
+You can override either or both of these defaults like this:
+
+    index_document: default.html
+    error_document: 404.html
+
+You can specify the name of any document in the bucket.
+
+
 ### Configuring redirects
 
 You can configure redirects on your S3 website by adding `routing_rules` into

--- a/lib/configure-s3-website/config_source/file_config_source.rb
+++ b/lib/configure-s3-website/config_source/file_config_source.rb
@@ -32,6 +32,14 @@ module ConfigureS3Website
       @config['routing_rules']
     end
 
+    def index_document_name
+      @config['index_document_name']
+    end
+
+    def error_document_name
+      @config['error_document_name']
+    end
+
     def cloudfront_distribution_config
       @config['cloudfront_distribution_config']
     end

--- a/lib/configure-s3-website/s3_client.rb
+++ b/lib/configure-s3-website/s3_client.rb
@@ -24,10 +24,10 @@ module ConfigureS3Website
       body = %|
         <WebsiteConfiguration xmlns='http://s3.amazonaws.com/doc/2006-03-01/'>
           <IndexDocument>
-            <Suffix>index.html</Suffix>
+            <Suffix>#{config_source.index_document_name || "index.html"}</Suffix>
           </IndexDocument>
           <ErrorDocument>
-            <Key>error.html</Key>
+            <Key>#{config_source.error_document_name || "error.html"}</Key>
           </ErrorDocument>
         </WebsiteConfiguration>
       |
@@ -66,10 +66,10 @@ module ConfigureS3Website
         body = %|
           <WebsiteConfiguration xmlns='http://s3.amazonaws.com/doc/2006-03-01/'>
             <IndexDocument>
-              <Suffix>index.html</Suffix>
+              <Suffix>#{config_source.index_document_name || "index.html"}</Suffix>
             </IndexDocument>
             <ErrorDocument>
-              <Key>error.html</Key>
+              <Key>#{config_source.error_document_name || "error.html"}</Key>
             </ErrorDocument>
             <RoutingRules>
         |


### PR DESCRIPTION
Fixes issue #4.

Apologies for lack of specs -- I could see existing specs for #create_bucket but not #enable_website_configuration...
