### PR TITLE
Update readme to use Version 2 cloudfront_distribution_config syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,11 @@ file. For example:
 ```yaml
 cloudfront_distribution_config:
   default_cache_behavior:
-    min_TTL: 600
+    min_ttl: 600
   aliases:
     quantity: 1
     items:
-      CNAME: your.domain.net
+      - your.domain.net
 ```
 
 See the section below for more information about the valid values of the
@@ -94,12 +94,12 @@ Let's say your config file contains the following fragment:
 cloudfront_distribution_id: AXSAXSSE134
 cloudfront_distribution_config:
   default_cache_behavior:
-    min_TTL: 600
+    min_ttl: 600
   default_root_object: index.json
 ```
 
 When you invoke `configure-s3-website`, it will overwrite the default value of
-*default_cache_behavior's* *min_TTL* as well as the default value of
+*default_cache_behavior's* *min_ttl* as well as the default value of
 *default_root_object* setting in the [default distribution configs](#default-distribution-configs).
 
 This gem generates `<DistributionConfig>` of the CloudFront REST API. For
@@ -151,7 +151,7 @@ Type](http://docs.aws.amazon.com/AmazonCloudFront/latest/APIReference/Distributi
       }
     },
     'viewer_protocol_policy' => 'allow-all',
-    'min_TTL' => '86400'
+    'min_ttl' => '86400'
   },
   'cache_behaviors' => {
     'quantity' => '0'


### PR DESCRIPTION
Context: Issue #17 

As of Version 2.0.0, s3_website configurations in `s3_website.yml` should change from

```yaml
default_cache_behavior:
  min_TTL: 600
aliases:
  quantity: 1
  items:
    CNAME: my.site.net
```

to

```yaml
default_cache_behavior:
  min_ttl: 600
aliases:
  quantity: 1
  items:
   - my.site.net
```

Users who have not applied the change will get the following errors for the CNAME or min_TTL options, respectively:

```
expected params[:distribution_config][:aliases][:items][0] to be a String, got value [:CNAME, "example.com"] (class: Array) instead. (ArgumentError)

unexpected value at params[:distribution_config][:default_cache_behavior][:min_TTL] (ArgumentError)
```

[V2.0.0 Changelog](https://github.com/laurilehmijoki/configure-s3-website/blob/master/changelog.md#200)