### PR TITLE
Add ability to use an AWS profile instead of explicit ‘s3_id’ and ‘s3_secret’

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 [![Build Status](https://secure.travis-ci.org/laurilehmijoki/configure-s3-website.png)](http://travis-ci.org/laurilehmijoki/configure-s3-website)
 [![Gem Version](https://fury-badge.herokuapp.com/rb/configure-s3-website.png)](http://badge.fury.io/rb/configure-s3-website)
 
-Configure an AWS S3 bucket to function as a website. Easily from the
-command-line interface.
+Configure an AWS S3 bucket to function as a website easily from a command-line interface.
 
 The bucket may or may not exist. If the bucket does not exist,
 `configure-s3-website` will create it.
@@ -17,7 +16,14 @@ For deploying websites to S3, consider using [s3_website](https://github.com/lau
 
 ## Usage
 
-Create a file that contains the S3 credentials and the name of the bucket:
+Create a file that contains the name of your AWS profile with access to S3 and the name of the bucket:
+
+```yaml
+profile: name-of-your-aws-profile-with-access
+s3_bucket: name-of-your-bucket
+```
+
+**or** create a file that contains the S3 credentials and the name of the bucket:
 
 ```yaml
 s3_id: your-aws-access-key

--- a/lib/configure-s3-website/config_source/file_config_source.rb
+++ b/lib/configure-s3-website/config_source/file_config_source.rb
@@ -78,10 +78,14 @@ module ConfigureS3Website
     end
 
     def self.validate_config(config, yaml_file_path)
-      required_keys = %w{s3_bucket}
-      missing_keys = required_keys.reject do |key| config.keys.include?key end
-      unless missing_keys.empty?
-        raise "File #{yaml_file_path} does not contain the required key(s) #{missing_keys.join(', ')}"
+      # make sure the bucket name is configured at a minimum
+      if not config.keys.include?'s3_bucket'
+        raise "File #{yaml_file_path} does not contain the required key 's3_bucket'"
+      end
+
+      # check that either s3_id or profile is configured
+      if not (config.keys.include?'s3_id' or config.keys.include?'profile')
+        raise "File #{yaml_file_path} does not contain either 's3_id' or 'profile'"
       end
     end
   end

--- a/lib/configure-s3-website/config_source/file_config_source.rb
+++ b/lib/configure-s3-website/config_source/file_config_source.rb
@@ -20,6 +20,10 @@ module ConfigureS3Website
       @config['s3_secret']
     end
 
+    def profile
+      @config['profile']
+    end
+
     def s3_bucket_name
       @config['s3_bucket']
     end
@@ -74,7 +78,7 @@ module ConfigureS3Website
     end
 
     def self.validate_config(config, yaml_file_path)
-      required_keys = %w{s3_id s3_secret s3_bucket}
+      required_keys = %w{s3_bucket}
       missing_keys = required_keys.reject do |key| config.keys.include?key end
       unless missing_keys.empty?
         raise "File #{yaml_file_path} does not contain the required key(s) #{missing_keys.join(', ')}"

--- a/lib/configure-s3-website/s3_client.rb
+++ b/lib/configure-s3-website/s3_client.rb
@@ -21,11 +21,18 @@ module ConfigureS3Website
     private
 
     def self.s3(config_source)
-      s3 = Aws::S3::Client.new(
-        region: config_source.s3_endpoint,
-        access_key_id: config_source.s3_access_key_id,
-        secret_access_key: config_source.s3_secret_access_key
-      )
+      if config_source.s3_access_key_id
+        Aws::S3::Client.new(
+          region: config_source.s3_endpoint,
+          access_key_id: config_source.s3_access_key_id,
+          secret_access_key: config_source.s3_secret_access_key
+        )
+      else
+        Aws::S3::Client.new(
+          region: config_source.s3_endpoint,
+          profile: config_source.profile,
+        )
+      end
     end
 
     def self.enable_website_configuration(config_source)


### PR DESCRIPTION
This change seeks to add the ability to use the well defined AWS profile credentials to access S3, instead of the previous `s3_id` and `s3_secret`, in a backward compatible manner.

You can now create a `config.yml` as:
```
profile: <aws_profile_name>
s3_bucket: <my_bucket_name>
```
where `profile` is defined in your `~/.aws/config` and `~/.aws/credentials` files,

instead of:
```
s3_id: <aws_key_id>
s3_secret: <aws_key_secret>
s3_bucket: <my_bucket_name>
```