### PR TITLE
Add support for default credentials providers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ s3_secret: your-aws-secret-key
 s3_bucket: name-of-your-bucket
 ```
 
+**or** you may omit the `profile` and `s3_id` keys to use the system's default credentials.
+This requires [configuring AWS credentials](http://docs.aws.amazon.com/sdk-for-ruby/v2/developer-guide/setup-config.html#aws-ruby-sdk-setting-credentials).
+Options include [setting environment variables](http://docs.aws.amazon.com/sdk-for-ruby/v2/developer-guide/setup-config.html#aws-ruby-sdk-credentials-environment),
+using a [shared credentials file](http://docs.aws.amazon.com/sdk-for-ruby/v2/developer-guide/setup-config.html#aws-ruby-sdk-credentials-shared),
+or running an [EC2 instance with IAM roles](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/UsingIAM.html#UsingIAMrolesWithAmazonEC2Instances).
+
 Save the file (as *config.yml*, for example). Now you are ready to go. Run the
 following command:
 

--- a/lib/configure-s3-website/config_source/file_config_source.rb
+++ b/lib/configure-s3-website/config_source/file_config_source.rb
@@ -82,11 +82,6 @@ module ConfigureS3Website
       if not config.keys.include?'s3_bucket'
         raise "File #{yaml_file_path} does not contain the required key 's3_bucket'"
       end
-
-      # check that either s3_id or profile is configured
-      if not (config.keys.include?'s3_id' or config.keys.include?'profile')
-        raise "File #{yaml_file_path} does not contain either 's3_id' or 'profile'"
-      end
     end
   end
 end

--- a/lib/configure-s3-website/s3_client.rb
+++ b/lib/configure-s3-website/s3_client.rb
@@ -27,10 +27,14 @@ module ConfigureS3Website
           access_key_id: config_source.s3_access_key_id,
           secret_access_key: config_source.s3_secret_access_key
         )
-      else
+      elsif config_source.profile
         Aws::S3::Client.new(
           region: config_source.s3_endpoint,
           profile: config_source.profile,
+        )
+      else
+        Aws::S3::Client.new(
+          region: config_source.s3_endpoint,
         )
       end
     end

--- a/spec/config_source/file_config_source_spec.rb
+++ b/spec/config_source/file_config_source_spec.rb
@@ -21,6 +21,14 @@ describe ConfigureS3Website::FileConfigSource do
     expect(config_source.description).to eq(yaml_file_path)
   end
 
+  it 'does not require s3_id, s3_secret or profile ' do
+    config_no_credentials = ConfigureS3Website::FileConfigSource.new('spec/sample_files/_config_file_no_credentials.yml')
+    expect(config_no_credentials.s3_access_key_id).to be_nil
+    expect(config_no_credentials.s3_secret_access_key).to be_nil
+    expect(config_no_credentials.profile).to be_nil
+    expect(config_no_credentials.s3_bucket_name).to eq('my-bucket')
+  end
+
   describe 'setter for cloudfront_distribution_id' do
     let(:original_yaml_contents) {
       %Q{

--- a/spec/s3_client_spec.rb
+++ b/spec/s3_client_spec.rb
@@ -144,4 +144,19 @@ describe ConfigureS3Website::S3Client do
       ConfigureS3Website::S3Client.configure_website({config_source: config_source})
     end
   end
+
+  context 's3_id, s3_secret and profile not required' do
+    let(:config_source) {
+      ConfigureS3Website::FileConfigSource.new('spec/sample_files/_config_file_no_credentials.yml')
+    }
+
+    it 'calls the S3 API successfully' do
+      allow_any_instance_of(Aws::S3::Client).to receive(:put_bucket_website).with(
+        hash_including(
+          :bucket => "my-bucket"
+        )
+      )
+      ConfigureS3Website::S3Client.configure_website({config_source: config_source})
+    end
+  end
 end

--- a/spec/sample_files/_config_file_no_credentials.yml
+++ b/spec/sample_files/_config_file_no_credentials.yml
@@ -1,0 +1,1 @@
+s3_bucket: my-bucket


### PR DESCRIPTION
Allow `s3_id`, `s3_secret`, and `profile` to be omitted. If they are, the Ruby SDK will fall back to the default credentials providers, which can use environment variables, credentials files, or IAM role information stored in instance metadata.

The motivation of this change is to bring configure-s3-website closer to s3_website, which supports configuration with omitted credentials.