### PR TITLE
Check for user input in cloudfront_client.rb

### DIFF
--- a/lib/configure-s3-website/cloudfront_client.rb
+++ b/lib/configure-s3-website/cloudfront_client.rb
@@ -42,7 +42,7 @@ module ConfigureS3Website
         puts 'Do you want to deliver your website via CloudFront, Amazon’s CDN service? [y/N]'
         user_answer = standard_input.gets
         print_headless_hint_and_exit if user_answer.nil?
-        case standard_input.gets.chomp
+        case user_answer.chomp
         when /(y|Y)/ then create_distribution options
         end
       end

--- a/lib/configure-s3-website/cloudfront_client.rb
+++ b/lib/configure-s3-website/cloudfront_client.rb
@@ -40,6 +40,8 @@ module ConfigureS3Website
         # Do nothing
       else
         puts 'Do you want to deliver your website via CloudFront, Amazon’s CDN service? [y/N]'
+        user_answer = standard_input.gets
+        print_headless_hint_and_exit if user_answer.nil?
         case standard_input.gets.chomp
         when /(y|Y)/ then create_distribution options
         end
@@ -69,6 +71,11 @@ module ConfigureS3Website
       unless custom_distribution_config.empty?
         print_report_on_custom_distribution_config custom_distribution_config
       end
+    end
+
+    def self.print_headless_hint_and_exit
+      puts 'No response detected. If you are running the command in a non-interactive session, you can use s3_website cfg apply --headless'
+      exit 1
     end
 
     def self.print_report_on_custom_distribution_config(custom_distribution_config, left_padding = 4)


### PR DESCRIPTION
When deploying using `s3_website` as part of a BitBucket pipeline, the following error was observed:

```
Do you want to deliver your website via CloudFront, Amazon’s CDN service? [y/N]
undefined method `chomp' for nil:NilClass (NoMethodError)
```

Adding a nil check with a meaningful hint to add `--headless`.